### PR TITLE
Use 1.0 core libraries

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,12 +19,12 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-maybe": "^0.3.0",
-    "purescript-foldable-traversable": "^0.4.0",
-    "purescript-strings": "^0.7.0"
+    "purescript-maybe": "^1.0.0",
+    "purescript-foldable-traversable": "^1.0.0",
+    "purescript-strings": "^1.0.0"
   },
   "devDependencies": {
-    "purescript-console": "~0.1.0",
+    "purescript-console": "^1.0.0",
     "purescript-super-spec": "~0.7.3"
   }
 }

--- a/src/Data/Char/Unicode.purs
+++ b/src/Data/Char/Unicode.purs
@@ -1,11 +1,23 @@
 
 module Data.Char.Unicode where
 
-import Prelude (class Bounded, class Ord, class Eq, class Show, (-), otherwise, (+), ($), (>=), (&&), (<=), (<<<), (||), (==), (<), map, compare)
+import Prelude
 
 import Data.Char (fromCharCode, toCharCode)
-import Data.Char.Unicode.Internal (UnicodeCategory(NUMCAT_CN, NUMCAT_CO, NUMCAT_CS, NUMCAT_CF, NUMCAT_CC, NUMCAT_ZP, NUMCAT_ZL, NUMCAT_ZS, NUMCAT_SO, NUMCAT_SK, NUMCAT_SC, NUMCAT_SM, NUMCAT_PO, NUMCAT_PF, NUMCAT_PI, NUMCAT_PE, NUMCAT_PS, NUMCAT_PD, NUMCAT_PC, NUMCAT_NO, NUMCAT_NL, NUMCAT_ND, NUMCAT_ME, NUMCAT_MC, NUMCAT_MN, NUMCAT_LO, NUMCAT_LM, NUMCAT_LT, NUMCAT_LL, NUMCAT_LU), uTowtitle, uTowlower, uTowupper, uIswalnum, uIswalpha, uIswlower, uIswupper, uIswspace, uIswprint, uIswcntrl, uGencat)
-import Data.Maybe (Maybe(Just, Nothing))
+import Data.Char.Unicode.Internal ( UnicodeCategory(..)
+                                  , uTowtitle
+                                  , uTowlower
+                                  , uTowupper
+                                  , uIswalnum
+                                  , uIswalpha
+                                  , uIswlower
+                                  , uIswupper
+                                  , uIswspace
+                                  , uIswprint
+                                  , uIswcntrl
+                                  , uGencat
+                                  )
+import Data.Maybe (Maybe(..))
 
 -- | Unicode General Categories (column 2 of the UnicodeData table) in
 -- | the order they are listed in the Unicode standard (the Unicode

--- a/src/Data/Char/Unicode/Internal.purs
+++ b/src/Data/Char/Unicode/Internal.purs
@@ -6,10 +6,10 @@
 
 module Data.Char.Unicode.Internal where
 
-import Prelude (class Show, map, (+), (<), (==), negate, otherwise, (>), (&&), (>=), show, (<>))
+import Prelude
 
 import Data.Foldable (elem, find)
-import Data.Maybe (Maybe(Just, Nothing))
+import Data.Maybe (Maybe(..))
 
 -- Unicode general categories, listed in the same order as in the Unicode
 -- standard. This must be the same order as in GHC.Unicode.
@@ -4857,4 +4857,3 @@ uGencat :: Int -> Maybe UnicodeCategory
 uGencat char =
     let conversionRule = getRule allchars char numBlocks
     in map (\(ConversionRule rule) -> rule.unicodeCat) conversionRule
-


### PR DESCRIPTION
@cdepillabout This bumps the core dependencies, but not `super-spec`, which needs to be updated. If it's possible to get a release out without worrying about tests for now, that would be good, since `purescript-parsing` depends on this library.

Thanks.
