### PR TITLE
Updates for 0.10

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,12 +19,14 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-maybe": "^1.0.0",
-    "purescript-foldable-traversable": "^1.0.0",
-    "purescript-strings": "^1.0.0"
+    "purescript-maybe": "^2.0.0",
+    "purescript-foldable-traversable": "^2.0.0",
+    "purescript-strings": "^2.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^1.0.0",
-    "purescript-super-spec": "~0.9.3"
+    "purescript-console": "^2.0.0",
+    "purescript-spec": "^0.10.0",
+    "purescript-random": "^2.0.0",
+    "purescript-quickcheck": "^3.0.0"
   }
 }

--- a/docs/Data/Char/Unicode.md
+++ b/docs/Data/Char/Unicode.md
@@ -390,10 +390,98 @@ letter, if any.  (Title case differs from upper case only for a small
 number of ligature letters.)
 Any other character is returned unchanged.
 
+#### `digitToInt`
+
+``` purescript
+digitToInt :: Char -> Maybe Int
+```
+
+Convert a single digit `Char` to the corresponding `Int`.  This
+function fails unless its argument satisfies `isHexDigit`, but
+recognises both upper- and lower-case hexadecimal digits (that
+is, `0..9, A..F, a..f`.
+
+*Examples*
+
+Characters `0` through `9` are converted properly to
+`0..9`:
+
+```
+>>> map digitToInt ['0'..'9']
+[0,1,2,3,4,5,6,7,8,9]
+```
+
+Both upper- and lower-case `A` through `F` are converted
+as well, to `10..15`.
+
+```
+>>> map digitToInt ['a'..'f']
+[10,11,12,13,14,15]
+>>> map digitToInt ['A'..'F']
+[10,11,12,13,14,15]
+```
+
+Anything else throws an exception:
+
+```
+>>> digitToInt 'G'
+*** Exception: Char.digitToInt: not a digit 'G'
+>>> digitToInt '♥'
+*** Exception: Char.digitToInt: not a digit '\9829'
+```
+
 #### `isLetter`
 
 ``` purescript
 isLetter :: Char -> Boolean
+```
+
+Selects alphabetic Unicode characters (lower-case, upper-case and
+title-case letters, plus letters of caseless scripts and
+modifiers letters). This function is equivalent to
+`Data.Char.isAlpha`.
+
+This function returns `True` if its argument has one of the
+following `GeneralCategory`s, or `False` otherwise:
+
+- `UppercaseLetter`
+- `LowercaseLetter`
+- `TitlecaseLetter`
+- `ModifierLetter`
+- `OtherLetter`
+
+These classes are defined in the
+[Unicode Character Database](http://www.unicode.org/reports/tr44/tr44-14.html#GC_Values_Table)
+part of the Unicode standard. The same document defines what is
+and is not a "Letter".
+
+*Examples*
+
+Basic usage:
+
+```
+>>> isLetter 'a'
+True
+>>> isLetter 'A'
+True
+>>> isLetter '0'
+False
+>>> isLetter '%'
+False
+>>> isLetter '♥'
+False
+>>> isLetter '\31'
+False
+```
+
+Ensure that 'isLetter' and 'isAlpha' are equivalent.
+
+```
+>>> let chars = [(chr 0)..]
+>>> let letters = map isLetter chars
+>>> let alphas = map isAlpha chars
+>>> letters == alphas
+True
 ```
 
 #### `isMark`

--- a/test/Test/Data/Char/Unicode.purs
+++ b/test/Test/Data/Char/Unicode.purs
@@ -3,14 +3,16 @@ module Test.Data.Char.Unicode (dataCharUnicodeTests) where
 
 import Prelude
 
+import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE())
 import Control.Monad.Eff.Exception (EXCEPTION())
 import Control.Monad.Eff.Random (RANDOM())
 import Data.Char (fromCharCode)
 import Data.Maybe (Maybe(..))
+import Test.QuickCheck (quickCheck)
 import Test.QuickCheck.Arbitrary (class Arbitrary)
 import Test.QuickCheck.Gen (Gen(), oneOf, chooseInt)
-import Test.Spec (Spec(), describe, it, prop)
+import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 
 import Data.Char.Unicode ( GeneralCategory(..)
@@ -179,24 +181,24 @@ instance arbitrayNonAsciiHexDigit :: Arbitrary NonAsciiHexDigit where
 
 isAsciiTests :: forall eff . Spec (console :: CONSOLE, random :: RANDOM, err :: EXCEPTION | eff) Unit
 isAsciiTests = describe "isAscii" do
-    prop "ascii chars are ascii" \(AsciiChar char) -> isAscii char
-    prop "non ascii chars are not ascii" \(NonAsciiChar char) -> not $ isAscii char
+    it "ascii chars are ascii" $ liftEff $ quickCheck \(AsciiChar char) -> isAscii char
+    it "non ascii chars are not ascii" $ liftEff $ quickCheck \(NonAsciiChar char) -> not $ isAscii char
 
 isLatin1Tests :: forall eff . Spec (console :: CONSOLE, random :: RANDOM, err :: EXCEPTION | eff) Unit
 isLatin1Tests = describe "isLatin1" do
-    prop "ascii chars are latin1" \(AsciiChar char) -> isLatin1 char
-    prop "latin1 chars are latin1" \(Latin1Char char) -> isLatin1 char
-    prop "non latin1 chars are not latin1" \(NonLatin1Char char) -> not $ isLatin1 char
+    it "ascii chars are latin1" $ liftEff $ quickCheck \(AsciiChar char) -> isLatin1 char
+    it "latin1 chars are latin1" $ liftEff $ quickCheck \(Latin1Char char) -> isLatin1 char
+    it "non latin1 chars are not latin1" $ liftEff $ quickCheck \(NonLatin1Char char) -> not $ isLatin1 char
 
 isAsciiLowerTests :: forall eff . Spec (console :: CONSOLE, random :: RANDOM, err :: EXCEPTION | eff) Unit
 isAsciiLowerTests = describe "isAsciiLower" do
-    prop "lower ascii chars are lower ascii" \(AsciiLowerChar char) -> isAsciiLower char
-    prop "non lower ascii chars are not lower ascii" \(NonAsciiLowerChar char) -> not $ isAsciiLower char
+    it "lower ascii chars are lower ascii" $ liftEff $ quickCheck \(AsciiLowerChar char) -> isAsciiLower char
+    it "non lower ascii chars are not lower ascii" $ liftEff $ quickCheck \(NonAsciiLowerChar char) -> not $ isAsciiLower char
 
 isAsciiUpperTests :: forall eff . Spec (console :: CONSOLE, random :: RANDOM, err :: EXCEPTION | eff) Unit
 isAsciiUpperTests = describe "isAsciiUpper" do
-    prop "upper ascii chars are upper ascii" \(AsciiUpperChar char) -> isAsciiUpper char
-    prop "non upper ascii chars are not upper ascii" \(NonAsciiUpperChar char) -> not $ isAsciiUpper char
+    it "upper ascii chars are upper ascii" $ liftEff $ quickCheck \(AsciiUpperChar char) -> isAsciiUpper char
+    it "non upper ascii chars are not upper ascii" $ liftEff $ quickCheck \(NonAsciiUpperChar char) -> not $ isAsciiUpper char
 
 isControlTests :: forall eff . Spec eff Unit
 isControlTests = describe "isControl" do
@@ -289,18 +291,18 @@ isAlphaNumTests = describe "isAlphaNum" do
 
 isDigitTests :: forall eff . Spec (console :: CONSOLE, random :: RANDOM, err :: EXCEPTION | eff) Unit
 isDigitTests = describe "isDigit" do
-    prop "digits are digits" \(AsciiDigit char) -> isDigit char
-    prop "non digits are not digits" \(NonAsciiDigit char) -> not $ isDigit char
+    it "digits are digits" $ liftEff $ quickCheck \(AsciiDigit char) -> isDigit char
+    it "non digits are not digits" $ liftEff $ quickCheck \(NonAsciiDigit char) -> not $ isDigit char
 
 isOctDigitTests :: forall eff . Spec (console :: CONSOLE, random :: RANDOM, err :: EXCEPTION | eff) Unit
 isOctDigitTests = describe "isOctDigit" do
-    prop "oct digits are oct digits" \(AsciiOctDigit char) -> isOctDigit char
-    prop "non oct digits are not oct digits" \(NonAsciiOctDigit char) -> not $ isOctDigit char
+    it "oct digits are oct digits" $ liftEff $ quickCheck \(AsciiOctDigit char) -> isOctDigit char
+    it "non oct digits are not oct digits" $ liftEff $ quickCheck \(NonAsciiOctDigit char) -> not $ isOctDigit char
 
 isHexDigitTests :: forall eff . Spec (console :: CONSOLE, random :: RANDOM, err :: EXCEPTION | eff) Unit
 isHexDigitTests = describe "isHexDigit" do
-    prop "hex digits are hex digits" \(AsciiHexDigit char) -> isHexDigit char
-    prop "non hex digits are not hex digits" \(NonAsciiHexDigit char) -> not $ isHexDigit char
+    it "hex digits are hex digits" $ liftEff $ quickCheck \(AsciiHexDigit char) -> isHexDigit char
+    it "non hex digits are not hex digits" $ liftEff $ quickCheck \(NonAsciiHexDigit char) -> not $ isHexDigit char
 
 isPunctuationTests :: forall eff . Spec eff Unit
 isPunctuationTests = describe "isPunctuation" do
@@ -364,7 +366,7 @@ digitToIntTests = describe "digitToInt" do
 
 isLetterTests:: forall eff . Spec (console :: CONSOLE, random :: RANDOM, err :: EXCEPTION | eff) Unit
 isLetterTests = describe "isLetter" do
-    prop "isLetter == isAlpha" \char -> isLetter char == isAlpha char
+    it "isLetter == isAlpha" $ liftEff $ quickCheck \char -> isLetter char == isAlpha char
 
 isMarkTests :: forall eff . Spec eff Unit
 isMarkTests = describe "isMark" do
@@ -396,7 +398,7 @@ isNumberTests = describe "isNumber" do
         isNumber '３' `shouldEqual` true
     it "'⑳' is Number" $
         isNumber '⑳' `shouldEqual` true
-    prop "0..9 are Number" \(AsciiDigit char) -> isNumber char
+    it "0..9 are Number" $ liftEff $ quickCheck \(AsciiDigit char) -> isNumber char
 
 isSeparatorTests :: forall eff . Spec eff Unit
 isSeparatorTests = describe "isSeparator" do

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -1,16 +1,15 @@
 module Test.Main where
 
 import Prelude
-
-import Control.Monad.Eff (Eff())
-import Control.Monad.Eff.Console (CONSOLE())
-import Control.Monad.Eff.Exception (EXCEPTION())
-import Control.Monad.Eff.Random (RANDOM())
-import Test.Spec.Runner (Process(), run)
-import Test.Spec.Reporter.Console (consoleReporter)
-
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE)
+import Control.Monad.Eff.Exception (EXCEPTION)
+import Control.Monad.Eff.Random (RANDOM)
+import Node.Process (PROCESS)
 import Test.Data.Char.Unicode (dataCharUnicodeTests)
+import Test.Spec.Reporter.Console (consoleReporter)
+import Test.Spec.Runner (run)
 
-main :: forall e . Eff (console :: CONSOLE, err :: EXCEPTION, process :: Process, random :: RANDOM | e) Unit
+main :: forall e . Eff (console :: CONSOLE, err :: EXCEPTION, process :: PROCESS, random :: RANDOM | e) Unit
 main = run [consoleReporter] $
     dataCharUnicodeTests


### PR DESCRIPTION
@cdepillabout The tests run and pass, but I switched to `purescript-spec`, which has been updated for 0.10, but which doesn't support quickcheck out of the box.

Also, you might want to consider switching to BSD3 or a compatible license, since I recently learned that BSD3 code cannot be relicensed under MIT.
