### PR TITLE
Fix link to `Data.Char.Unicode.Internal`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This directory contains documentation for `unicode`. If you are interested in co
 
 ## Generating Internal Modules
 
-The [Data.Char.Unicode.Internal](src/Data/Char/Unicode/Internal.purs) module can be generated with the following command:
+The [Data.Char.Unicode.Internal](../src/Data/Char/Unicode/Internal.purs) module can be generated with the following command:
 
 ```sh
 $ wget 'http://www.unicode.org/Public/6.0.0/ucd/UnicodeData.txt'


### PR DESCRIPTION
It looks like the link got broken by the rearrangement of the docs in #26.