### PR TITLE
Deprecate `isDigit` and `digitToInt` in favor of functions which specify base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes (😱!!!):
+- Deprecation warnings for `isDigit` and `digitToInt` #25
 
 New features:
+- Added `hexDigitToInt` `decDigitToInt` `octDigitToInt` #25
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes (😱!!!):
-- Deprecation warnings for `isDigit` and `digitToInt` #25
+- Deprecation warnings for `isDigit` and `digitToInt` (#31 by @milesfrain)
 
 New features:
-- Added `hexDigitToInt` `decDigitToInt` `octDigitToInt` #25
+- Added `hexDigitToInt` `decDigitToInt` `octDigitToInt` (#31 by @milesfrain)
 
 Bugfixes:
 

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/prepare-0.14/src/packages.dhall sha256:f591635bcfb73053bcb6de2ecbf2896489fa5b580563396f52a1051ede439849
+      https://raw.githubusercontent.com/purescript/package-sets/prepare-0.14/src/packages.dhall sha256:af6c012eccebfc7447440e486d3ab8fbab02abaa003a540de62e204351d50a98
 
 in  upstream

--- a/src/Data/Char/Unicode.purs
+++ b/src/Data/Char/Unicode.purs
@@ -9,9 +9,9 @@ module Data.Char.Unicode
   , isAlpha
   , isAlphaNum
   , isLetter
+  , isHexDigit
   , isDecDigit
   , isOctDigit
-  , isHexDigit
   , isDigit -- Deprecated
   , isControl
   , isPrint
@@ -23,8 +23,9 @@ module Data.Char.Unicode
   , isNumber
 
 -- Conversion to Int
-  , decDigitToInt
   , hexDigitToInt
+  , decDigitToInt
+  , octDigitToInt
   , digitToInt -- Deprecated
 
   -- Case conversion
@@ -580,17 +581,28 @@ hexDigitToInt c = result
 -- | Nothing
 -- | ```
 decDigitToInt :: Char -> Maybe Int
-decDigitToInt c = result
-  where
-    result :: Maybe Int
-    result
-      | dec <= 9 && dec >= 0 = Just dec
-      | otherwise            = Nothing
+decDigitToInt c
+  | isDecDigit c = Just $ toCharCode c - toCharCode '0'
+  | otherwise    = Nothing
 
-    dec :: Int
-    dec = toCharCode c - toCharCode '0'
+-- | Convert a single digit `Char` to the corresponding `Just Int` if its argument
+-- | satisfies `isOctDigit` (one of `0..7`). Anything else converts to `Nothing`
+-- |
+-- | ```
+-- | >>> import Data.Traversable
+-- |
+-- | >>> traverse octDigitToInt ['0','1','2','3','4','5','6','7']
+-- | (Just [0,1,2,3,4,5,6,7])
+-- |
+-- | >>> octDigitToInt '8'
+-- | Nothing
+-- | ```
+octDigitToInt :: Char -> Maybe Int
+octDigitToInt c
+  | isOctDigit c = Just $ toCharCode c - toCharCode '0'
+  | otherwise    = Nothing
 
-digitToInt :: Warn (Text "'digitToInt' is deprecated, use 'decDigitToInt' or 'hexDigitToInt' instead") => Char -> Maybe Int
+digitToInt :: Warn (Text "'digitToInt' is deprecated, use 'decDigitToInt', 'hexDigitToInt', or 'octDigitToInt' instead") => Char -> Maybe Int
 digitToInt = hexDigitToInt
 
 -- | Selects alphabetic Unicode characters (lower-case, upper-case and

--- a/test/Test/Data/Char/Unicode.purs
+++ b/test/Test/Data/Char/Unicode.purs
@@ -9,6 +9,7 @@ import Data.Char.Unicode (GeneralCategory(..), decDigitToInt, hexDigitToInt, oct
 import Data.Maybe (Maybe(..), fromJust)
 import Data.Monoid (power, guard)
 import Data.NonEmpty ((:|))
+import Data.String.CodeUnits (singleton)
 import Effect.Console (log)
 import Effect.Class (class MonadEffect, liftEffect)
 import Partial.Unsafe (unsafePartial)
@@ -354,6 +355,12 @@ toLowerTests = pure unit
 toTitleTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
 toTitleTests = pure unit
 
+notDigit :: forall m. MonadReader Int m => MonadEffect m =>
+  String -> (Char -> Maybe Int) -> Char -> m Unit
+notDigit base func char =
+  it ("'" <> singleton char <> "' is not a " <> base <> " digit") $
+      func char `shouldEqual` Nothing
+
 hexDigitToIntTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
 hexDigitToIntTests = describe "hexDigitToInt" do
     it "'0'..'9' get mapped correctly" $
@@ -365,36 +372,27 @@ hexDigitToIntTests = describe "hexDigitToInt" do
     it "'A'..'F' get mapped correctly" $
         map hexDigitToInt ['A','B','C','D','E','F'] `shouldEqual`
             [Just 10, Just 11, Just 12, Just 13, Just 14, Just 15]
-    it "'G' is not a hex digit" $
-        hexDigitToInt 'G' `shouldEqual` Nothing
-    it "'♥' is not a hex digit" $
-        hexDigitToInt '♥' `shouldEqual` Nothing
-    it "'国' is not a hex digit" $
-        hexDigitToInt '国' `shouldEqual` Nothing
+    notDigit "hex" hexDigitToInt 'G'
+    notDigit "hex" hexDigitToInt '♥'
+    notDigit "hex" hexDigitToInt '国'
 
 decDigitToIntTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
 decDigitToIntTests = describe "decDigitToInt" do
     it "'0'..'9' get mapped correctly" $
         map decDigitToInt ['0','1','2','3','4','5','6','7','8','9'] `shouldEqual`
             [Just 0, Just 1, Just 2, Just 3, Just 4, Just 5, Just 6, Just 7, Just 8, Just 9]
-    it "'a' is not a dec digit" $
-        decDigitToInt 'a' `shouldEqual` Nothing
-    it "'♥' is not a dec digit" $
-        decDigitToInt '♥' `shouldEqual` Nothing
-    it "'国' is not a dec digit" $
-        decDigitToInt '国' `shouldEqual` Nothing
+    notDigit "dec" decDigitToInt 'a'
+    notDigit "dec" decDigitToInt '♥'
+    notDigit "dec" decDigitToInt '国'
 
 octDigitToIntTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
 octDigitToIntTests = describe "octDigitToInt" do
     it "'0'..'7' get mapped correctly" $
         map octDigitToInt ['0','1','2','3','4','5','6','7'] `shouldEqual`
             [Just 0, Just 1, Just 2, Just 3, Just 4, Just 5, Just 6, Just 7]
-    it "'8' is not a oct digit" $
-        octDigitToInt 'G' `shouldEqual` Nothing
-    it "'♥' is not a oct digit" $
-        octDigitToInt '♥' `shouldEqual` Nothing
-    it "'国' is not a oct digit" $
-        octDigitToInt '国' `shouldEqual` Nothing
+    notDigit "oct" octDigitToInt '8'
+    notDigit "oct" octDigitToInt '♥'
+    notDigit "oct" octDigitToInt '国'
 
 isLetterTests:: forall m. MonadReader Int m => MonadEffect m => m Unit
 isLetterTests = describe "isLetter" do

--- a/test/Test/Data/Char/Unicode.purs
+++ b/test/Test/Data/Char/Unicode.purs
@@ -6,6 +6,7 @@ import Prelude
 import Control.Monad.Reader.Class (class MonadReader, ask, local)
 import Data.Char (fromCharCode)
 import Data.Char.Unicode (GeneralCategory(..), decDigitToInt, hexDigitToInt, octDigitToInt, generalCategory, isAlpha, isAlphaNum, isAscii, isAsciiLower, isAsciiUpper, isControl, isDecDigit, isHexDigit, isLatin1, isLetter, isLower, isMark, isNumber, isOctDigit, isPrint, isPunctuation, isSeparator, isSpace, isSymbol, isUpper)
+import Data.Foldable (traverse_)
 import Data.Maybe (Maybe(..), fromJust)
 import Data.Monoid (power, guard)
 import Data.NonEmpty ((:|))
@@ -372,27 +373,21 @@ hexDigitToIntTests = describe "hexDigitToInt" do
     it "'A'..'F' get mapped correctly" $
         map hexDigitToInt ['A','B','C','D','E','F'] `shouldEqual`
             [Just 10, Just 11, Just 12, Just 13, Just 14, Just 15]
-    notDigit "hex" hexDigitToInt 'G'
-    notDigit "hex" hexDigitToInt '♥'
-    notDigit "hex" hexDigitToInt '国'
+    traverse_ (notDigit "hex" hexDigitToInt) ['g', 'G', '♥', '国']
 
 decDigitToIntTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
 decDigitToIntTests = describe "decDigitToInt" do
     it "'0'..'9' get mapped correctly" $
         map decDigitToInt ['0','1','2','3','4','5','6','7','8','9'] `shouldEqual`
             [Just 0, Just 1, Just 2, Just 3, Just 4, Just 5, Just 6, Just 7, Just 8, Just 9]
-    notDigit "dec" decDigitToInt 'a'
-    notDigit "dec" decDigitToInt '♥'
-    notDigit "dec" decDigitToInt '国'
+    traverse_ (notDigit "dec" decDigitToInt) ['a', 'A', '♥', '国']
 
 octDigitToIntTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
 octDigitToIntTests = describe "octDigitToInt" do
     it "'0'..'7' get mapped correctly" $
         map octDigitToInt ['0','1','2','3','4','5','6','7'] `shouldEqual`
             [Just 0, Just 1, Just 2, Just 3, Just 4, Just 5, Just 6, Just 7]
-    notDigit "oct" octDigitToInt '8'
-    notDigit "oct" octDigitToInt '♥'
-    notDigit "oct" octDigitToInt '国'
+    traverse_ (notDigit "oct" octDigitToInt) ['8', '9', '♥', '国']
 
 isLetterTests:: forall m. MonadReader Int m => MonadEffect m => m Unit
 isLetterTests = describe "isLetter" do

--- a/test/Test/Data/Char/Unicode.purs
+++ b/test/Test/Data/Char/Unicode.purs
@@ -5,7 +5,7 @@ import Prelude
 
 import Control.Monad.Reader.Class (class MonadReader, ask, local)
 import Data.Char (fromCharCode)
-import Data.Char.Unicode (GeneralCategory(..), digitToInt, generalCategory, isAlpha, isAlphaNum, isAscii, isAsciiLower, isAsciiUpper, isControl, isDigit, isHexDigit, isLatin1, isLetter, isLower, isMark, isNumber, isOctDigit, isPrint, isPunctuation, isSeparator, isSpace, isSymbol, isUpper)
+import Data.Char.Unicode (GeneralCategory(..), decDigitToInt, hexDigitToInt, octDigitToInt, generalCategory, isAlpha, isAlphaNum, isAscii, isAsciiLower, isAsciiUpper, isControl, isDecDigit, isHexDigit, isLatin1, isLetter, isLower, isMark, isNumber, isOctDigit, isPrint, isPunctuation, isSeparator, isSpace, isSymbol, isUpper)
 import Data.Maybe (Maybe(..), fromJust)
 import Data.Monoid (power, guard)
 import Data.NonEmpty ((:|))
@@ -53,15 +53,17 @@ dataCharUnicodeTests = describe "module Data.Char.Unicode" do
     isUpperTests
     isAlphaTests
     isAlphaNumTests
-    isDigitTests
-    isOctDigitTests
     isHexDigitTests
+    isDecDigitTests
+    isOctDigitTests
     isPunctuationTests
     isSymbolTests
     toUpperTests
     toLowerTests
     toTitleTests
-    digitToIntTests
+    hexDigitToIntTests
+    decDigitToIntTests
+    octDigitToIntTests
     isLetterTests
     isMarkTests
     isNumberTests
@@ -295,10 +297,10 @@ isAlphaNumTests = describe "isAlphaNum" do
     it "'\\n' is not AlphaNum" $
         isAlphaNum '\n' `shouldEqual` false
 
-isDigitTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
-isDigitTests = describe "isDigit" do
-    it "digits are digits" $ liftEffect $ quickCheck \(AsciiDigit char) -> isDigit char
-    it "non digits are not digits" $ liftEffect $ quickCheck \(NonAsciiDigit char) -> not $ isDigit char
+isDecDigitTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
+isDecDigitTests = describe "isDecDigit" do
+    it "digits are digits" $ liftEffect $ quickCheck \(AsciiDigit char) -> isDecDigit char
+    it "non digits are not digits" $ liftEffect $ quickCheck \(NonAsciiDigit char) -> not $ isDecDigit char
 
 isOctDigitTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
 isOctDigitTests = describe "isOctDigit" do
@@ -352,23 +354,47 @@ toLowerTests = pure unit
 toTitleTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
 toTitleTests = pure unit
 
-digitToIntTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
-digitToIntTests = describe "digitToInt" do
+hexDigitToIntTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
+hexDigitToIntTests = describe "hexDigitToInt" do
     it "'0'..'9' get mapped correctly" $
-        map digitToInt ['0','1','2','3','4','5','6','7','8','9'] `shouldEqual`
+        map hexDigitToInt ['0','1','2','3','4','5','6','7','8','9'] `shouldEqual`
             [Just 0, Just 1, Just 2, Just 3, Just 4, Just 5, Just 6, Just 7, Just 8, Just 9]
     it "'a'..'f' get mapped correctly" $
-        map digitToInt ['a','b','c','d','e','f'] `shouldEqual`
+        map hexDigitToInt ['a','b','c','d','e','f'] `shouldEqual`
             [Just 10, Just 11, Just 12, Just 13, Just 14, Just 15]
     it "'A'..'F' get mapped correctly" $
-        map digitToInt ['A','B','C','D','E','F'] `shouldEqual`
+        map hexDigitToInt ['A','B','C','D','E','F'] `shouldEqual`
             [Just 10, Just 11, Just 12, Just 13, Just 14, Just 15]
-    it "'G' is not a digit" $
-        digitToInt 'G' `shouldEqual` Nothing
-    it "'♥' is not a digit" $
-        digitToInt '♥' `shouldEqual` Nothing
-    it "'国' is not a digit" $
-        digitToInt '国' `shouldEqual` Nothing
+    it "'G' is not a hex digit" $
+        hexDigitToInt 'G' `shouldEqual` Nothing
+    it "'♥' is not a hex digit" $
+        hexDigitToInt '♥' `shouldEqual` Nothing
+    it "'国' is not a hex digit" $
+        hexDigitToInt '国' `shouldEqual` Nothing
+
+decDigitToIntTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
+decDigitToIntTests = describe "decDigitToInt" do
+    it "'0'..'9' get mapped correctly" $
+        map decDigitToInt ['0','1','2','3','4','5','6','7','8','9'] `shouldEqual`
+            [Just 0, Just 1, Just 2, Just 3, Just 4, Just 5, Just 6, Just 7, Just 8, Just 9]
+    it "'a' is not a dec digit" $
+        decDigitToInt 'a' `shouldEqual` Nothing
+    it "'♥' is not a dec digit" $
+        decDigitToInt '♥' `shouldEqual` Nothing
+    it "'国' is not a dec digit" $
+        decDigitToInt '国' `shouldEqual` Nothing
+
+octDigitToIntTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
+octDigitToIntTests = describe "octDigitToInt" do
+    it "'0'..'7' get mapped correctly" $
+        map octDigitToInt ['0','1','2','3','4','5','6','7'] `shouldEqual`
+            [Just 0, Just 1, Just 2, Just 3, Just 4, Just 5, Just 6, Just 7]
+    it "'8' is not a oct digit" $
+        octDigitToInt 'G' `shouldEqual` Nothing
+    it "'♥' is not a oct digit" $
+        octDigitToInt '♥' `shouldEqual` Nothing
+    it "'国' is not a oct digit" $
+        octDigitToInt '国' `shouldEqual` Nothing
 
 isLetterTests:: forall m. MonadReader Int m => MonadEffect m => m Unit
 isLetterTests = describe "isLetter" do


### PR DESCRIPTION
**Description of the change**
Fixes #25

Now we have symmetric:
```
isHexDigit        
isDecDigit        
isOctDigit        
hexDigitToInt        
decDigitToInt        
octDigitToInt
```
---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Added a test for the contribution (if applicable)

Not Applicable:
- _Updated or added relevant documentation in the README and/or documentation directory_
  - I think the API docs in the function comments are enough in this case.