### PR TITLE
Fix unused warning: also run isLowerTests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
-- Run `isLowerTests` in tests (#35 by@JordanMartinez)
+- Run `isLowerTests` in tests (#35 by @JordanMartinez)
 
 ## [v5.0.0](https://github.com/purescript-contrib/purescript-unicode/releases/tag/v5.0.0) - 2021-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Run `isLowerTests` in tests (#35 by@JordanMartinez)
 
 ## [v5.0.0](https://github.com/purescript-contrib/purescript-unicode/releases/tag/v5.0.0) - 2021-02-26
 

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,14 +1,21 @@
 { name = "unicode"
 , dependencies =
-  [ "assert"
+  [ "arrays"
+  , "assert"
   , "console"
   , "effect"
+  , "enums"
   , "foldable-traversable"
+  , "integers"
   , "maybe"
+  , "partial"
+  , "prelude"
   , "psci-support"
   , "quickcheck"
   , "random"
   , "strings"
+  , "transformers"
+  , "unsafe-coerce"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/test/Test/Data/CodePoint/Unicode.purs
+++ b/test/Test/Data/CodePoint/Unicode.purs
@@ -54,6 +54,7 @@ dataCharUnicodeTests = describe "module Data.CodePoint.Unicode" do
     isPrintTests
     isSpaceTests
     isUpperTests
+    isLowerTests
     isAlphaTests
     isAlphaNumTests
     isDecDigitTests


### PR DESCRIPTION
**Description of the change**

Fix another warning found in the test code. `isLowerTests` wasn't being run.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
