### PR TITLE
Add an `isSpace` test for a CJK character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bugfixes:
 
 Other improvements:
 - Run `isLowerTests` in tests (#35 by @JordanMartinez)
+- Added test for CJK characters for `isSpace` (#36 by @maxdeviant)
 
 ## [v5.0.0](https://github.com/purescript-contrib/purescript-unicode/releases/tag/v5.0.0) - 2021-02-26
 

--- a/test/Test/Data/CodePoint/Unicode.purs
+++ b/test/Test/Data/CodePoint/Unicode.purs
@@ -238,6 +238,8 @@ isSpaceTests = describe "isSpace" do
         isSpace (codePointFromChar '\t') `shouldEqual` true
     it "'a' is not Space" $
         isSpace (codePointFromChar 'a') `shouldEqual` false
+    it "'日' is not Space" $
+        isSpace (codePointFromChar '日') `shouldEqual` false
 
 isUpperTests :: forall m. MonadReader Int m => MonadEffect m => m Unit
 isUpperTests = describe "isUpper" do


### PR DESCRIPTION
**Description of the change**

This PR adds a test for `isSpace` using a CJK character.

An issue with CJK characters when used with `isSpace` was previously reported in #20. The issue is no longer reproducible on `main`, but it's probably good to have some test coverage for this path to ensure there are no regressions.

Closes #20.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
